### PR TITLE
Add API blueprint documentation

### DIFF
--- a/boxychat.api
+++ b/boxychat.api
@@ -1,0 +1,61 @@
+FORMAT: 1A
+
+# BoxyChat
+BoxyChat is a real time communication tool, it let's you send messages, share files, etc
+
+# Group Auth
+Auth related resources for **BoxyChat API**
+
+## Auth - Signup [/user]
+### Create a new account [POST]
++ Request (application/json)
+
+        { "email": "email@test.com", "password": "donothackme" }
+
++ Response 201 (application/json)
+
+        { "id": "1", "email": "email@test.com" }
+
++ Response 500 (application/json)
+
+        { "error": {
+            "code": 101,
+            "message": "Email already exists" 
+            }
+        }
+
+## Auth - Activate [/activate/{token}]
+
++ Parameters
+    + token (required, string, `KIUDEHUID7E9830IU23JDH2`) ... String `Token` of the Account to perform activation with.
+
+### Activate a newly create account [GET]
++ Response 200 (application/json)
+
+        { "message": "ok" }
+
++ Response 500 (application/json)
+
+        { "error": {
+            "code": "110",
+            "message": "Token was not found"
+            }
+        }
+
+## Auth - Login [/login]
+### Make Login [POST]
++ Request (application/json)
+
+        { "email": "email@test.com", "password": "donothackme" }
+
++ Response 200 (application/json)
+
+        { "access_token": "UHD7897U389IHE378Z3" }
+
++ Response 500 (application/json)
+
+        { "error": {
+            "code": 120,
+            "message": "Wrong credentials 
+            }
+        }


### PR DESCRIPTION
I've added the boxychat.api file containing an API Blueprint compatible definition.
I've opted for API Blueprint "style" because it give us some advantages, for example we could use the following tools.
**Aglio** is an API Blueprint renderer with theme support that outputs static HTML. We could use it to generate our documentation, we can even have themes, so it's up to our taste.

**Dredd** is an API Blueprint testing tool. This one is quite cool, with always the same file of documentation we can give it to Dredd and it is going to run it against our APIs. We could integrate it in Travis CI

Here's an example of how it looks with Aglio: http://cl.ly/image/0p3a3m3N0b36
